### PR TITLE
Fix spelling issue in en_us

### DIFF
--- a/src/main/resources/assets/daily_rewards/lang/en_us.json
+++ b/src/main/resources/assets/daily_rewards/lang/en_us.json
@@ -10,7 +10,7 @@
   "text.daily_rewards.reward_screen": "Rewarded Days: %1$s day(s)",
   "text.daily_rewards.reward_screen_none": "Daily Rewards",
   "text.daily_rewards.rewarded_item_empty": "Reward Item is empty, please check the logs and the configuration!",
-  "text.daily_rewards.rewarded_item": "Congratulation %1$s you got %2$s as regonization for %3$s day(s) in this world for this month.",
+  "text.daily_rewards.rewarded_item": "Congratulation %1$s you got %2$s as recognition for %3$s day(s) in this world for this month.",
   "text.daily_rewards.unclaimed_rewarded_item": "%1$s you have unclaimed daily rewards, please make sure to claim them in the next %2$s days!",
   "text.daily_rewards.unclaimed_rewarded_item_today": "%1$s you have unclaimed daily rewards, please make sure to claim them today!!!",
   "text.daily_rewards.unclaimed_special_rewarded_item": "%1$s you have unclaimed daily special rewards, please make sure to claim them in the next %2$s days!",


### PR DESCRIPTION
This typo seems to appear in the other branches as well.